### PR TITLE
Fix dataset schema payload types and release v3.0.4

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -3,7 +3,7 @@
   "name": "webhook-debugger-logger",
   "title": "Webhook Debugger, Logger & API Mocking Suite",
   "description": "Enterprise-grade tool to test, debug, and mock webhooks. Features real-time SSE streaming, request replay, HTTP forwarding, and JSON schema validation. Perfect for Stripe, GitHub, and Shopify integrations.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "output": "./output_schema.json",
   "input": "./input_schema.json",
   "webServerSchema": "./web_server_schema.json",

--- a/.actor/dataset_schema.json
+++ b/.actor/dataset_schema.json
@@ -64,10 +64,22 @@
           },
           {
             "type": "object"
+          },
+          {
+            "type": "array"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
           }
         ],
         "title": "Body",
-        "description": "The raw request body as text, or a parsed/offloaded payload object",
+        "description": "The raw request body as text, or a parsed/offloaded JSON payload",
         "example": {
           "status": "success"
         }
@@ -121,6 +133,18 @@
           },
           {
             "type": "object"
+          },
+          {
+            "type": "array"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
           }
         ],
         "title": "Response Body",

--- a/.actor/dataset_schema.json
+++ b/.actor/dataset_schema.json
@@ -58,10 +58,19 @@
         }
       },
       "body": {
-        "type": "string",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object"
+          }
+        ],
         "title": "Body",
-        "description": "The raw or parsed request body",
-        "example": "{\"status\": \"success\"}"
+        "description": "The raw request body as text, or a parsed/offloaded payload object",
+        "example": {
+          "status": "success"
+        }
       },
       "contentType": {
         "type": "string",
@@ -106,16 +115,27 @@
         "example": 200
       },
       "responseBody": {
-        "type": "string",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object"
+          }
+        ],
         "title": "Response Body",
-        "description": "Body returned to the webhook sender",
-        "example": "{\"received\": true}"
+        "description": "Response body returned to the webhook sender as text or JSON",
+        "example": {
+          "received": true
+        }
       },
       "responseHeaders": {
         "type": "object",
         "title": "Response Headers",
         "description": "Headers returned to the webhook sender",
-        "example": { "content-type": "application/json" }
+        "example": {
+          "content-type": "application/json"
+        }
       },
       "signatureProvider": {
         "type": "string",
@@ -153,17 +173,41 @@
       "display": {
         "component": "table",
         "properties": {
-          "timestamp": { "label": "Time", "format": "date" },
-          "requestId": { "label": "Req ID" },
-          "signatureValid": { "label": "Sig", "format": "boolean" },
-          "webhookId": { "label": "Webhook ID" },
-          "method": { "label": "Method" },
-          "statusCode": { "label": "Status" },
-          "contentType": { "label": "Content-Type" },
-          "size": { "label": "Size (Bytes)" },
-          "processingTime": { "label": "Latency (ms)" },
-          "remoteIp": { "label": "Source IP" },
-          "signatureProvider": { "label": "Provider" }
+          "timestamp": {
+            "label": "Time",
+            "format": "date"
+          },
+          "requestId": {
+            "label": "Req ID"
+          },
+          "signatureValid": {
+            "label": "Sig",
+            "format": "boolean"
+          },
+          "webhookId": {
+            "label": "Webhook ID"
+          },
+          "method": {
+            "label": "Method"
+          },
+          "statusCode": {
+            "label": "Status"
+          },
+          "contentType": {
+            "label": "Content-Type"
+          },
+          "size": {
+            "label": "Size (Bytes)"
+          },
+          "processingTime": {
+            "label": "Latency (ms)"
+          },
+          "remoteIp": {
+            "label": "Source IP"
+          },
+          "signatureProvider": {
+            "label": "Provider"
+          }
         }
       }
     },
@@ -189,18 +233,49 @@
       "display": {
         "component": "table",
         "properties": {
-          "timestamp": { "label": "Time", "format": "date" },
-          "requestId": { "label": "Req ID" },
-          "signatureValid": { "label": "Sig", "format": "boolean" },
-          "method": { "label": "Method" },
-          "statusCode": { "label": "Status" },
-          "query": { "label": "Query", "format": "object" },
-          "headers": { "label": "Headers", "format": "object" },
-          "body": { "label": "Body", "format": "text" },
-          "responseBody": { "label": "Res Body", "format": "text" },
-          "responseHeaders": { "label": "Res Headers", "format": "object" },
-          "signatureProvider": { "label": "Sig Provider" },
-          "signatureError": { "label": "Sig Error" }
+          "timestamp": {
+            "label": "Time",
+            "format": "date"
+          },
+          "requestId": {
+            "label": "Req ID"
+          },
+          "signatureValid": {
+            "label": "Sig",
+            "format": "boolean"
+          },
+          "method": {
+            "label": "Method"
+          },
+          "statusCode": {
+            "label": "Status"
+          },
+          "query": {
+            "label": "Query",
+            "format": "object"
+          },
+          "headers": {
+            "label": "Headers",
+            "format": "object"
+          },
+          "body": {
+            "label": "Body",
+            "format": "text"
+          },
+          "responseBody": {
+            "label": "Res Body",
+            "format": "text"
+          },
+          "responseHeaders": {
+            "label": "Res Headers",
+            "format": "object"
+          },
+          "signatureProvider": {
+            "label": "Sig Provider"
+          },
+          "signatureError": {
+            "label": "Sig Error"
+          }
         }
       }
     }

--- a/.actor/web_server_schema.json
+++ b/.actor/web_server_schema.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Webhook Debugger & Logger API",
     "description": "OpenAPI description for the Webhook Debugger & Logger Actor web server. Authentication is configuration-driven: when authKey is configured, management routes require either a bearer token or the key query parameter; when authKey is unset, those routes remain accessible without credentials.",
-    "version": "3.0.3"
+    "version": "3.0.4"
   },
   "servers": [
     {
@@ -80,7 +80,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "example": "Webhook Debugger & Logger (v3.0.3)\nActive Webhooks: 1\nSignature Verification: STRIPE"
+                "example": "Webhook Debugger & Logger (v3.0.4)\nActive Webhooks: 1\nSignature Verification: STRIPE"
               }
             }
           },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2026-04-18
+
+### Fixed (3.0.4)
+
+- **Apify**: Relax the dataset storage schema for `body` and `responseBody` so webhook events can be stored when request or response payloads are captured as parsed JSON objects instead of plain strings.
+- **Tests**: Add a regression test that keeps the Actor dataset schema aligned with the webhook payload shapes persisted by the runtime.
+
 ## [3.0.3] - 2026-04-18
 
 ### Fixed (3.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed (3.0.4)
 
-- **Apify**: Relax the dataset storage schema for `body` and `responseBody` so webhook events can be stored when request or response payloads are captured as parsed JSON objects instead of plain strings.
+- **Apify**: Relax the dataset storage schema for `body` and `responseBody` so webhook events can be stored when request or response payloads are captured as any JSON-compatible values instead of only strings and objects.
 - **Tests**: Add a regression test that keeps the Actor dataset schema aligned with the webhook payload shapes persisted by the runtime.
 
 ## [3.0.3] - 2026-04-18

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webhook-debugger-logger",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webhook-debugger-logger",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "ISC",
       "dependencies": {
         "@duckdb/node-api": "^1.4.3-r.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webhook-debugger-logger",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "type": "module",
   "description": "Generate temporary webhook URLs and log all incoming requests with full details.",
   "main": "src/main.js",

--- a/tests/unit/actor/input_schema.test.js
+++ b/tests/unit/actor/input_schema.test.js
@@ -8,7 +8,9 @@ import { getInputSchemaSecretFieldKeys } from "@apify/input_secrets";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
+const Ajv = require("ajv").default;
 const inputSchema = require("../../../.actor/input_schema.json");
+const datasetSchema = require("../../../.actor/dataset_schema.json");
 
 /**
  * @param {unknown} value
@@ -128,5 +130,28 @@ describe("Apify input schema", () => {
     const missingDescriptions = findMissingDescriptions(inputSchema, "schema");
 
     expect(missingDescriptions).toEqual([]);
+  });
+});
+
+describe("Apify dataset schema", () => {
+  it("allows webhook body fields to be stored as either string or object", () => {
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(datasetSchema.fields);
+
+    expect(
+      validate({
+        body: { status: "success" },
+        responseBody: { received: true },
+      }),
+    ).toBe(true);
+    expect(validate.errors).toBeNull();
+
+    expect(
+      validate({
+        body: '{"status":"success"}',
+        responseBody: '{"received":true}',
+      }),
+    ).toBe(true);
+    expect(validate.errors).toBeNull();
   });
 });

--- a/tests/unit/actor/input_schema.test.js
+++ b/tests/unit/actor/input_schema.test.js
@@ -134,8 +134,8 @@ describe("Apify input schema", () => {
 });
 
 describe("Apify dataset schema", () => {
-  it("allows webhook body fields to be stored as either string or object", () => {
-    const ajv = new Ajv({ strict: false });
+  it("allows webhook body fields to be stored in the runtime-supported JSON shapes", () => {
+    const ajv = new Ajv({ strict: false, validateFormats: false });
     const validate = ajv.compile(datasetSchema.fields);
 
     expect(
@@ -153,5 +153,36 @@ describe("Apify dataset schema", () => {
       }),
     ).toBe(true);
     expect(validate.errors).toBeNull();
+
+    expect(
+      validate({
+        body: ["first", "second"],
+        responseBody: null,
+      }),
+    ).toBe(true);
+    expect(validate.errors).toBeNull();
+
+    expect(
+      validate({
+        body: 123,
+        responseBody: true,
+      }),
+    ).toBe(true);
+    expect(validate.errors).toBeNull();
+
+    expect(
+      validate({
+        body: false,
+        responseBody: ["one", "two", "three"],
+      }),
+    ).toBe(true);
+    expect(validate.errors).toBeNull();
+
+    expect(
+      validate({
+        body: () => "not-json",
+      }),
+    ).toBe(false);
+    expect(validate.errors).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- allow `.actor/dataset_schema.json` to accept object payloads for `body` and `responseBody`
- add a regression test that validates both string and object payload shapes against the dataset schema
- bump the project version to `3.0.4`, sync generated actor metadata, and update the changelog

## Verification
- `npm run validate:schemas`
- `npm run test:jest -- tests/unit/actor/input_schema.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 3.0.4 Release Notes

* **Bug Fixes**
  * Enhanced dataset schema to accept webhook payloads in multiple formats: both parsed JSON objects and text strings can now be stored for request and response body fields.

* **Documentation**
  * Updated changelog documenting schema enhancements and new regression test coverage.

* **Tests**
  * Added regression tests validating webhook payload schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->